### PR TITLE
FIX: Fix view operations for q, k, v in multi-head attention

### DIFF
--- a/zh/ch8-attention-and-transformer/ch8.4-multi-head-attention.qmd
+++ b/zh/ch8-attention-and-transformer/ch8.4-multi-head-attention.qmd
@@ -266,9 +266,9 @@ class MultiheadAttention(nn.Module):
         k = self.k_proj(key)
         v = self.v_proj(value)
 
-        q = query.view(batch_size, q_len, self.num_heads, self.head_dim)
-        k = key.view(batch_size, k_len, self.num_heads, self.head_dim)
-        v = value.view(batch_size, v_len, self.num_heads, self.head_dim)
+        q = q.view(batch_size, q_len, self.num_heads, self.head_dim)
+        k = k.view(batch_size, k_len, self.num_heads, self.head_dim)
+        v = v.view(batch_size, v_len, self.num_heads, self.head_dim)
 
         q = q.transpose(1, 2)
         k = k.transpose(1, 2)


### PR DESCRIPTION
## Type of change

- [x] Fixes an error or unclear explanation in the notes
- [ ] Improves wording, structure, formatting, or references
- [ ] Adds or updates examples, derivations, or code comments
- [ ] Updates `dnnlpy` package code
- [ ] Updates repository tooling, build, or workflow files
- [ ] Other:

## Description

Fix view operations for q, k, v in multi-head attention.

## Checklist

- [x] I've read the [[Contributing Guidelines](https://github.com/jshn9515/deep-learning-notes/blob/main/CONTRIBUTING.md)].

## Related issue

N/A