### PR TITLE
FIX: Remove extra 'not' in zero_grad example code for both zh and en versions

### DIFF
--- a/en/ch2-pytorch-introduction/ch2.5-optimizer.qmd
+++ b/en/ch2-pytorch-introduction/ch2.5-optimizer.qmd
@@ -216,7 +216,7 @@ y = torch.randn(8, 1)
 loss = F.mse_loss(model(x), y)
 loss.backward()
 
-flag1 = model.weight.grad is not None
+flag1 = model.weight.grad is None
 print('Whether grad is None before zero_grad?', flag1)
 
 optimizer.zero_grad(set_to_none=True)

--- a/zh/ch2-pytorch-introduction/ch2.5-optimizer.qmd
+++ b/zh/ch2-pytorch-introduction/ch2.5-optimizer.qmd
@@ -216,7 +216,7 @@ y = torch.randn(8, 1)
 loss = F.mse_loss(model(x), y)
 loss.backward()
 
-flag1 = model.weight.grad is not None
+flag1 = model.weight.grad is None
 print('Whether grad is None before zero_grad?', flag1)
 
 optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Type of change

- [ ] Fixes an error or unclear explanation in the notes
- [x] Improves wording, structure, formatting, or references
- [ ] Adds or updates examples, derivations, or code comments
- [ ] Updates `dnnlpy` package code
- [ ] Updates repository tooling, build, or workflow files
- [ ] Other:

## Description

Fixed a logical contradiction in section 2.5.3 (`ch2.5-optimizer.qmd`) for both the English and Chinese versions.

In the example code, the print statement asks `"Whether grad is None before zero_grad?"`, but `flag1` was previously evaluating `model.weight.grad is not None`.So I removed the extra `not` to matche the question being asked.

## Checklist

- [x] I've read the [[Contributing Guidelines](https://github.com/jshn9515/deep-learning-notes/blob/main/CONTRIBUTING.md)].

## Related issue

N/A

### Note
To keep the Git diff clean and avoid noise from random neural network initializations (`.png`, `.svg`, etc.), I purposely only committed the `.qmd` source files. I am unsure if this repository has a CI/CD workflow (like GitHub Actions) configured to automatically re-render Quarto files upon merging.  If not, you may need to manually re-render the files locally after merging. Alternatively, please feel free to treat this PR just as an Issue report and apply the fix directly on your end. 

Thanks for the great tutorial!