### PR TITLE
[zh] FIX: Correct conv2d output size example variable name

### DIFF
--- a/zh/ch5-convolutional-neural-network/ch5.2-convolution.qmd
+++ b/zh/ch5-convolutional-neural-network/ch5.2-convolution.qmd
@@ -340,7 +340,7 @@ for stride, padding in [(1, 0), (1, 1), (2, 1)]:
     )
     expected = F.conv2d(x, weight, stride=stride, padding=padding)
 
-    print(f'stride={stride}, padding={padding}: actual={actual}, expected={y.size(-1)}')
+    print(f'stride={stride}, padding={padding}: actual={actual}, expected={expected.size(-1)}')
 ```
 
 输出尺寸公式是理解 CNN 结构时最常用的公式之一。读网络结构图时，只要知道输入大小、kernel、padding 和 stride，就可以逐层计算特征图尺寸。


### PR DESCRIPTION
## Type of change

<!-- Check all that apply. -->

- [x] Fixes an error or unclear explanation in the notes
- [ ] Improves wording, structure, formatting, or references
- [x] Adds or updates examples, derivations, or code comments
- [ ] Updates `dnnlpy` package code
- [ ] Updates repository tooling, build, or workflow files
- [ ] Other:

## Description

Fix a variable name error in the `conv2d` output size example.

The example stores the result of `F.conv2d(...)` in `expected`, but the print statement used `y.size(-1)`, where `y` was not defined. This PR updates the print statement to use `expected.size(-1)` so the notebook cell can run correctly and compare the formula result with the actual PyTorch output.

## Checklist

<!-- Check the items that apply, and add commands or notes where useful. -->

- [x] I've read the [Contributing Guidelines](https://github.com/jshn9515/deep-learning-notes/blob/main/CONTRIBUTING.md).

## Related issue

None.